### PR TITLE
Implemented full CRUD functionality for Weekly Groove:

### DIFF
--- a/groovetime/urls.py
+++ b/groovetime/urls.py
@@ -5,11 +5,13 @@ from django.conf.urls import include
 from rest_framework import routers
 
 from groovetimeapi.views import (
-    RatingView
+    RatingView,
+    WeeklyGrooveView
 )
 
 router = routers.DefaultRouter(trailing_slash=False)
 router.register(r'ratings', RatingView, 'rating')
+router.register(r'weeklygrooves', WeeklyGrooveView, 'weeklygroove')
 
 
 urlpatterns = [

--- a/groovetimeapi/fixtures/weekly_grooves.json
+++ b/groovetimeapi/fixtures/weekly_grooves.json
@@ -15,8 +15,8 @@
     "pk": 2,
     "fields": {
       "active": false,
-      "title": "abandoned mall vibes",
-      "description": "you're 17, just got outta prom with your shitty girlfriend, you're chillin-- tryna not to go home but... man! what's this? a text from the homeboy chris?? abandoned mall??? he and carson finally found a way in???? cut to the memory of sitting at the edge of a food court, music playing towards the end of the dying speaker carson bought, and a shared cigarette. what song just happened to be the best song to play on that speaker?",
+      "title": "bleeding out in the snow...",
+      "description": "heartbeat slows. cold's numbing. tragic. i should get up, but... im getting warmer, i think. yeah...",
       "start_day": "Tuesday, February 4th, 2025",
       "end_day": "Tuesday, February 11th, 2025"
     }
@@ -26,8 +26,8 @@
     "pk": 3,
     "fields": {
       "active": true,
-      "title": "bleeding out in the snow...",
-      "description": "heartbeat slows. cold's numbing. tragic. i should get up, but... im getting warmer, i think. yeah...",
+      "title": "liminal teenage angst",
+      "description": "you're 17, just got outta prom with your shitty girlfriend, you're chillin-- tryna not to go home but... man! what's this? a text from the homeboy chris?? abandoned mall??? he and carson finally found a way in???? cut to the memory of sitting at the edge of a food court, music playing towards the end of the dying speaker carson bought, and a shared cigarette. what song just happened to be the best song to play on that speaker?",
       "start_day": "Tuesday, March 1st, 2025",
       "end_day": "Tuesday, March 8th, 2025"
     }

--- a/groovetimeapi/views/__init__.py
+++ b/groovetimeapi/views/__init__.py
@@ -1,1 +1,2 @@
 from .rating import RatingView
+from .weekly_groove import WeeklyGrooveView

--- a/groovetimeapi/views/weekly_groove.py
+++ b/groovetimeapi/views/weekly_groove.py
@@ -1,0 +1,75 @@
+from django.http import HttpResponseServerError
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import serializers, status
+from groovetimeapi.models import WeeklyGroove
+
+
+class WeeklyGrooveView(ViewSet):
+
+    def retrieve(self, request, pk):
+
+        try:
+
+            weekly_groove = WeeklyGroove.objects.get(pk=pk)
+            serializer = WeeklyGrooveSerializer(weekly_groove)
+            return Response(serializer.data)
+
+        except WeeklyGroove.DoesNotExist as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+
+    def list(self, request):
+        active = request.query_params.get('active', None)
+
+        weekly_grooves = WeeklyGroove.objects.all()
+
+        if active is not None:
+            weekly_grooves = weekly_grooves.filter(active=active)
+
+        serializer = WeeklyGrooveSerializer(weekly_grooves, many=True)
+        return Response(serializer.data)
+
+    def create(self, request):
+        WeeklyGroove.objects.filter(active=True).update(active=False)
+
+        weekly_groove = WeeklyGroove.objects.create(
+            active=request.data["active"],
+            title=request.data["title"],
+            description=request.data["description"],
+            start_day=request.data["startDay"],
+            end_day=request.data["endDay"]
+        )
+
+        serializer = WeeklyGrooveSerializer(weekly_groove)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+    def update(self, request, pk):
+
+        weekly_groove = WeeklyGroove.objects.get(pk=pk)
+        weekly_groove.active = request.data["active"]
+        weekly_groove.title = request.data["title"]
+        weekly_groove.description = request.data["description"]
+        weekly_groove.start_day = request.data["startDay"]
+        weekly_groove.end_day = request.data["endDay"]
+
+        weekly_groove.save()
+        return Response(None, status=status.HTTP_204_NO_CONTENT)
+
+    def destroy(self, request, pk):
+
+        weekly_groove = WeeklyGroove.objects.get(pk=pk)
+        weekly_groove.delete()
+        return Response(None, status=status.HTTP_204_NO_CONTENT)
+
+
+class WeeklyGrooveSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = WeeklyGroove
+        fields = (
+            'active',
+            'title',
+            'description',
+            'start_day',
+            'end_day'
+        )


### PR DESCRIPTION
- List all Weekly Grooves (`GET /weeklygrooves`)
- Retrieve a single Weekly Groove (`GET /weeklygrooves/<id>`)
- Retrieve active Weekly Groove (`GET /weeklygrooves?active=True`)
- Retrieve inactive Weekly Grooves (`GET /weeklygrooves?active=False`)
- Create, update, and delete Weekly Grooves

Note that upon addition of new Weekly Groove, past Weekly Groove is automatically set as INACTIVE.