### PR TITLE
Add CRUD for User Ratings AND FULL! FUNCTIONALITY!

### DIFF
--- a/groovetime/urls.py
+++ b/groovetime/urls.py
@@ -8,7 +8,8 @@ from groovetimeapi.views import (
     RatingView,
     WeeklyGrooveView,
     GrooveSubmissionView,
-    GroovetimeUserView
+    GroovetimeUserView,
+    GrooveSubmissionRatingView
 )
 
 router = routers.DefaultRouter(trailing_slash=False)
@@ -16,6 +17,8 @@ router.register(r'ratings', RatingView, 'rating')
 router.register(r'weeklygrooves', WeeklyGrooveView, 'weeklygroove')
 router.register(r'groovesubmissions', GrooveSubmissionView, 'groovesubmission')
 router.register(r'groovetimeusers', GroovetimeUserView, 'groovetimeuser')
+router.register(r'groovesubmissionratings',
+                GrooveSubmissionRatingView, 'groovesubmissionrating')
 
 
 urlpatterns = [

--- a/groovetimeapi/views/__init__.py
+++ b/groovetimeapi/views/__init__.py
@@ -2,3 +2,6 @@ from .rating import RatingView
 from .weekly_groove import WeeklyGrooveView
 from .groove_submission import GrooveSubmissionView
 from .groovetime_user import GroovetimeUserView
+from .groove_submission_rating import GrooveSubmissionRatingView
+
+from .update_user_points import update_user_groove_points

--- a/groovetimeapi/views/groove_submission.py
+++ b/groovetimeapi/views/groove_submission.py
@@ -8,6 +8,8 @@ from groovetimeapi.models import (
     GroovetimeUser,
 )
 
+from .update_user_points import update_user_groove_points
+
 
 class GrooveSubmissionView(ViewSet):
 
@@ -69,6 +71,7 @@ class GrooveSubmissionView(ViewSet):
             submitted_by=submitted_by
         )
 
+        update_user_groove_points(submitted_by)
         serializer = GrooveSubmissionSerializer(groove_submission)
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 

--- a/groovetimeapi/views/groove_submission_rating.py
+++ b/groovetimeapi/views/groove_submission_rating.py
@@ -1,0 +1,91 @@
+from django.http import HttpResponseServerError
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import serializers, status
+
+from groovetimeapi.models import (
+    GroovetimeUser,
+    GrooveSubmission,
+    Rating,
+    GrooveSubmissionRating,
+)
+
+from .update_user_points import update_user_groove_points
+
+
+class GrooveSubmissionRatingView(ViewSet):
+
+    def retrieve(self, request, pk):
+        single_submission_rating = GrooveSubmissionRating.objects.get(pk=pk)
+        serializer = GrooveSubmissionRatingSerializer(
+            single_submission_rating)
+        return Response(serializer.data)
+
+    def list(self, request):
+        groove_submission = request.query_params.get('groove_submission', None)
+
+        all_submission_ratings = GrooveSubmissionRating.objects.all()
+
+        if groove_submission is not None:
+            all_submission_ratings = all_submission_ratings.filter(
+                groove_submission=groove_submission)
+
+        # show ratings attached to a particular submission
+
+        serializer = GrooveSubmissionRatingSerializer(
+            all_submission_ratings, many=True)
+        return Response(serializer.data)
+
+    def create(self, request):
+
+        groove_submission = GrooveSubmission.objects.get(
+            pk=request.data["grooveSubmission"])
+        user_submitted = GroovetimeUser.objects.get(
+            pk=request.data["userSubmitted"])
+        rating_value = Rating.objects.get(pk=request.data["ratingValue"])
+
+        if not groove_submission.weekly_groove.active:
+            return Response(
+                {"message": "You can only rate submissions from the active Weekly Groove."},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        existing_rating = GrooveSubmissionRating.objects.filter(
+            groove_submission=groove_submission,
+            user_submitted=user_submitted
+        ).count()
+
+        if existing_rating >= 1:
+            return Response(
+                {"message": "You already rated this submission!"},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        groove_submission_rating = GrooveSubmissionRating.objects.create(
+            groove_submission=groove_submission,
+            user_submitted=user_submitted,
+            rating_value=rating_value
+        )
+
+        groove_submission.user_ratings.add(rating_value)
+        all_ratings = groove_submission.user_ratings.values_list(
+            'value', flat=True)
+
+        groove_submission.average_rating = sum(
+            all_ratings) / len(all_ratings) if all_ratings else None
+
+        groove_submission.save()
+        update_user_groove_points(groove_submission.submitted_by)
+
+        serializer = GrooveSubmissionRatingSerializer(groove_submission_rating)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+
+class GrooveSubmissionRatingSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = GrooveSubmissionRating
+        fields = (
+            'groove_submission',
+            'user_submitted',
+            'rating_value'
+        )

--- a/groovetimeapi/views/update_user_points.py
+++ b/groovetimeapi/views/update_user_points.py
@@ -1,0 +1,13 @@
+from groovetimeapi.models import GrooveSubmission, GroovetimeUser
+
+
+def update_user_groove_points(user):
+
+    user_submissions = GrooveSubmission.objects.filter(submitted_by=user)
+    total_average_ratings = sum(
+        sub.average_rating for sub in user_submissions if sub.average_rating is not None)
+
+    grooves_won_bonus = user.grooves_won * 10
+
+    user.groove_points = total_average_ratings + grooves_won_bonus
+    user.save()


### PR DESCRIPTION
Users can only submit if:
  The Groove Submission is for a Weekly Groove that is active
  The user has not already submitted a Ratings

When a rating is submitted:
  The many to many rating object is appended onto that submission's 'user_ratings' field
  That submission's 'average_rating' field is dynamically updated -- the average of the rating object values.
  That submission's user's 'groove_points' field is updated

!! modular !! function has been created to update the user's points

When a new Weekly Groove is submitted:
  User with highest groove submission rating that week earns +1 to their 'grooves_won' field
  ALL users Groove Points are updated

Points are THE SUM of the following:
  The sum of all average ratings of all submissions for a user
  A user's groove_points * 10

Function to update user's points are used at:
  Adding a rating (user's rated submission)
  New Weekly Groove (all users)
  New Submission (user submitted)